### PR TITLE
Fix misspelling of "DoxyPress".

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,7 +111,7 @@ static void useage()
    printf("email: info@copperspice.com\n");
 
    printf("\n");
-   printf("Usage: DoxyPessApp [OPTIONS] [project file name]\n");
+   printf("Usage: DoxyPressApp [OPTIONS] [project file name]\n");
 
    printf("\n\n");
    printf("Convert Doxygen project file to DoxyPress format: \n");


### PR DESCRIPTION
This also occurs in the documentation, but I can't seem to find the source for it. The typo in the documentation is on this page:

https://www.copperspice.com/docs/doxypress/doxypressapp-usage.html